### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Codecov.yaml
+++ b/.github/workflows/Codecov.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   codecov:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SylarLong/iztro/security/code-scanning/1](https://github.com/SylarLong/iztro/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow, the `contents: read` permission is sufficient for most steps, and no additional write permissions are required. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
