### PR TITLE
docs: 补充纯 Python 重写版生态入口

### DIFF
--- a/README-en_US.md
+++ b/README-en_US.md
@@ -86,6 +86,17 @@ It's used to obtain the data of `The Purple Star Astrology (Zi Wei Dou Shu)`.
 - [Issues](https://github.com/SylarLong/iztro/issues)
 - [Demo](https://ziwei.pub)
 
+## Python Ecosystem
+
+If you need a **native Python** implementation that does not depend on the JavaScript/Node.js runtime at execution time, you can also check this third-party project:
+
+- [`izthon`](https://github.com/TaoracleHQ/izthon)
+
+Notes:
+
+- `izthon` is a new pure-Python rewrite that follows `iztro` behavior as its reference/specification.
+- It is not part of the official `iztro` repository, but it aims to stay behaviorally aligned with `iztro` as much as possible.
+
 ## Online Demo
 
 To instantly access iztro's astrolabe with no development required, go directly to https://ziwei.pub for online demo.

--- a/README-zh_TW.md
+++ b/README-zh_TW.md
@@ -100,6 +100,17 @@
 - [問題](https://github.com/SylarLong/iztro/issues)
 - [排盤](https://ziwei.pub)
 
+## Python 生態
+
+如果你需要一個 **原生 Python** 的版本（執行時不依賴 JavaScript/Node.js），可以參考第三方專案：
+
+- [`izthon`](https://github.com/TaoracleHQ/izthon)
+
+說明：
+
+- `izthon` 是一個新的純 Python 重寫版，以 `iztro` 的行為作為規格參考。
+- 它不是 `iztro` 官方倉庫的一部分，但目標是盡量與 `iztro` 的行為與測試保持一致。
+
 ## 立即使用
 
 若您不想自己動手寫程式，只想直接查看 `iztro` 的排盤結果，歡迎直接使用 [紫微派（ziwei.pub）](https://ziwei.pub) 的線上排盤服務。

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@
 - [问题](https://github.com/SylarLong/iztro/issues)
 - [排盘](https://ziwei.pub)
 
+## Python 生态
+
+如果你需要一个 **原生 Python** 的版本（运行时不依赖 JavaScript/Node.js），可以参考第三方项目：
+
+- [`izthon`](https://github.com/TaoracleHQ/izthon)
+
+说明：
+
+- `izthon` 是一个新的纯 Python 重写版，以 `iztro` 的行为为规格参考。
+- 它不是 `iztro` 官方仓库的一部分，但目标是尽量与 `iztro` 的行为和测试保持一致。
+
 ## 直接使用
 
 如果你想要零开发直接查看 `iztro` 的排盘结果，请直接使用 [紫微派（ziwei.pub）](https://ziwei.pub) 在线排盘。


### PR DESCRIPTION
这个 PR 想补充一个很小的生态说明：

- 在 `README.md`
- 在 `README-zh_TW.md`
- 在 `README-en_US.md`

新增一段 `Python` 生态入口，介绍第三方项目 `izthon`：

- 仓库地址：https://github.com/TaoracleHQ/izthon
- 它是一个新的纯 Python 重写版
- 运行时不依赖 JavaScript / Node.js
- 以 `iztro` 的行为作为规格参考
- 明确说明它不是 `iztro` 官方仓库的一部分

这样做的目的主要是方便有 **原生 Python** 需求的用户找到对应实现，同时避免误解成官方 Python 子项目。

如果你觉得放在 README 不合适，也可以告诉我更合适的位置，我可以继续调整。
