### PR TITLE
fix(i18n): correct ko-KR originalPalace '라인' → '래인' (來因)

### DIFF
--- a/src/i18n/locales/ko-KR/palace.ts
+++ b/src/i18n/locales/ko-KR/palace.ts
@@ -12,5 +12,5 @@ export default {
   propertyPalace: '전택',
   spiritPalace: '복덕',
   parentsPalace: '부모',
-  originalPalace: '라인',
+  originalPalace: '래인',
 } as const;


### PR DESCRIPTION
fix(i18n): correct ko-KR originalPalace '라인' → '래인' (來因)